### PR TITLE
Steering Wheel widget truncated value

### DIFF
--- a/src/rqt_gauges/steering_wheel_gauge.py
+++ b/src/rqt_gauges/steering_wheel_gauge.py
@@ -159,7 +159,7 @@ class SteeringWheelGauge(QWidget):
         # Create Gauge Text
         pen.setColor(QColor(self.text_color))
         painter.setPen(pen)
-        painter.drawText(rect, Qt.AlignCenter, f'{self.value}{self.suffix}')
+        painter.drawText(rect, Qt.AlignCenter, f'{self.value:.2f}{self.suffix}')
         # End Painter
         painter.end()
 


### PR DESCRIPTION
Related with this issue https://github.com/ToyotaResearchInstitute/gauges2/issues/26

![steering_wheel_truncated](https://github.com/ToyotaResearchInstitute/gauges2/assets/1933907/ed5bf4c0-1fd5-48d9-b22c-53f11e5ca278)

FYI @caguero